### PR TITLE
remove -j optiion

### DIFF
--- a/osx/binutils-aarch64.rb
+++ b/osx/binutils-aarch64.rb
@@ -15,7 +15,7 @@ class BinutilsAarch64 < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-alpha.rb
+++ b/osx/binutils-alpha.rb
@@ -15,7 +15,7 @@ class BinutilsAlpha < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-amd64.rb
+++ b/osx/binutils-amd64.rb
@@ -15,7 +15,7 @@ class BinutilsAmd64 < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-arm.rb
+++ b/osx/binutils-arm.rb
@@ -15,7 +15,7 @@ class BinutilsArm < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-avr.rb
+++ b/osx/binutils-avr.rb
@@ -15,7 +15,7 @@ class BinutilsAvr < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-cris.rb
+++ b/osx/binutils-cris.rb
@@ -15,7 +15,7 @@ class BinutilsCris < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-hppa.rb
+++ b/osx/binutils-hppa.rb
@@ -15,7 +15,7 @@ class BinutilsHppa < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-i386.rb
+++ b/osx/binutils-i386.rb
@@ -15,7 +15,7 @@ class BinutilsI386 < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-ia64.rb
+++ b/osx/binutils-ia64.rb
@@ -15,7 +15,7 @@ class BinutilsIa64 < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-m68k.rb
+++ b/osx/binutils-m68k.rb
@@ -15,7 +15,7 @@ class BinutilsM68K < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-mips.rb
+++ b/osx/binutils-mips.rb
@@ -15,7 +15,7 @@ class BinutilsMips < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-mips64.rb
+++ b/osx/binutils-mips64.rb
@@ -15,7 +15,7 @@ class BinutilsMips64 < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-msp430.rb
+++ b/osx/binutils-msp430.rb
@@ -15,7 +15,7 @@ class BinutilsMsp430 < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-powerpc.rb
+++ b/osx/binutils-powerpc.rb
@@ -15,7 +15,7 @@ class BinutilsPowerpc < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-powerpc64.rb
+++ b/osx/binutils-powerpc64.rb
@@ -15,7 +15,7 @@ class BinutilsPowerpc64 < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-s390.rb
+++ b/osx/binutils-s390.rb
@@ -15,7 +15,7 @@ class BinutilsS390 < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-sparc.rb
+++ b/osx/binutils-sparc.rb
@@ -15,7 +15,7 @@ class BinutilsSparc < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-vax.rb
+++ b/osx/binutils-vax.rb
@@ -15,7 +15,7 @@ class BinutilsVax < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end

--- a/osx/binutils-xscale.rb
+++ b/osx/binutils-xscale.rb
@@ -15,7 +15,7 @@ class BinutilsXscale < Formula
                           "--disable-multilib",
                           "--disable-nls",
                           "--disable-werror"
-    system "make", "-j"
+    system "make"
     system "make", "install"
     system "rm", "-rf", "#{prefix}/share/info"
   end


### PR DESCRIPTION
I tried to install pwntools-binutils in mac, but terminal freezed. The cause was  'make -j'. 'j option' make so many jobs. It is heavy. Non option is better
