### PR TITLE
Make install_all.sh not require an unused argument

### DIFF
--- a/ubuntu/install_all.sh
+++ b/ubuntu/install_all.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 source ../common/arch.sh
 
-if [[ $# -ne 1 ]];
-then
-echo "usage: $0 architecture"
-else
 sudo apt-get install --yes software-properties-common
 sudo apt-add-repository --yes ppa:pwntools/binutils
 sudo apt-get update
@@ -12,4 +8,3 @@ sudo apt-get update
 for arch in $ARCHES; do
 sudo apt-get install binutils-$arch-linux-gnu
 done
-fi


### PR DESCRIPTION
It seems that install_all.sh was created by copy/pasting install.sh and making a few modifications. However, when this happened, the code checking for at least one argument (the architecture) was left in the code.
