### PR TITLE
SHA1 deprecated. Replace with SHA256

### DIFF
--- a/osx/binutils-aarch64.rb
+++ b/osx/binutils-aarch64.rb
@@ -2,7 +2,7 @@ class BinutilsAarch64 < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-alpha.rb
+++ b/osx/binutils-alpha.rb
@@ -2,7 +2,7 @@ class BinutilsAlpha < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-amd64.rb
+++ b/osx/binutils-amd64.rb
@@ -2,7 +2,7 @@ class BinutilsAmd64 < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-arm.rb
+++ b/osx/binutils-arm.rb
@@ -2,7 +2,7 @@ class BinutilsArm < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-avr.rb
+++ b/osx/binutils-avr.rb
@@ -2,7 +2,7 @@ class BinutilsAvr < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-cris.rb
+++ b/osx/binutils-cris.rb
@@ -2,7 +2,7 @@ class BinutilsCris < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-hppa.rb
+++ b/osx/binutils-hppa.rb
@@ -2,7 +2,7 @@ class BinutilsHppa < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-i386.rb
+++ b/osx/binutils-i386.rb
@@ -2,7 +2,7 @@ class BinutilsI386 < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-ia64.rb
+++ b/osx/binutils-ia64.rb
@@ -2,7 +2,7 @@ class BinutilsIa64 < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-m68k.rb
+++ b/osx/binutils-m68k.rb
@@ -2,7 +2,7 @@ class BinutilsM68K < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-mips.rb
+++ b/osx/binutils-mips.rb
@@ -2,7 +2,7 @@ class BinutilsMips < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-mips64.rb
+++ b/osx/binutils-mips64.rb
@@ -2,7 +2,7 @@ class BinutilsMips64 < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-msp430.rb
+++ b/osx/binutils-msp430.rb
@@ -2,7 +2,7 @@ class BinutilsMsp430 < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-powerpc.rb
+++ b/osx/binutils-powerpc.rb
@@ -2,7 +2,7 @@ class BinutilsPowerpc < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-powerpc64.rb
+++ b/osx/binutils-powerpc64.rb
@@ -2,7 +2,7 @@ class BinutilsPowerpc64 < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-s390.rb
+++ b/osx/binutils-s390.rb
@@ -2,7 +2,7 @@ class BinutilsS390 < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-sparc.rb
+++ b/osx/binutils-sparc.rb
@@ -2,7 +2,7 @@ class BinutilsSparc < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-vax.rb
+++ b/osx/binutils-vax.rb
@@ -2,7 +2,7 @@ class BinutilsVax < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 

--- a/osx/binutils-xscale.rb
+++ b/osx/binutils-xscale.rb
@@ -2,7 +2,7 @@ class BinutilsXscale < Formula
   homepage "http://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
   mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 


### PR DESCRIPTION
As per https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Checksum_Deprecation.md SHA1 hashes will be deprecated by September 2016.
