### PR TITLE
fix binutils instance clashes in MacOS.

### DIFF
--- a/macos/binutils-aarch64.rb
+++ b/macos/binutils-aarch64.rb
@@ -10,6 +10,7 @@ class BinutilsAarch64 < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=aarch64-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-alpha.rb
+++ b/macos/binutils-alpha.rb
@@ -10,6 +10,7 @@ class BinutilsAlpha < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=alpha-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-amd64.rb
+++ b/macos/binutils-amd64.rb
@@ -10,6 +10,7 @@ class BinutilsAmd64 < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=amd64-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-arm.rb
+++ b/macos/binutils-arm.rb
@@ -10,6 +10,7 @@ class BinutilsArm < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=arm-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-avr.rb
+++ b/macos/binutils-avr.rb
@@ -10,6 +10,7 @@ class BinutilsAvr < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=avr-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-cris.rb
+++ b/macos/binutils-cris.rb
@@ -10,6 +10,7 @@ class BinutilsCris < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=cris-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-hppa.rb
+++ b/macos/binutils-hppa.rb
@@ -10,6 +10,7 @@ class BinutilsHppa < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=hppa-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-i386.rb
+++ b/macos/binutils-i386.rb
@@ -10,6 +10,7 @@ class BinutilsI386 < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=i386-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-ia64.rb
+++ b/macos/binutils-ia64.rb
@@ -10,6 +10,7 @@ class BinutilsIa64 < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=ia64-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-m68k.rb
+++ b/macos/binutils-m68k.rb
@@ -10,6 +10,7 @@ class BinutilsM68k < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=m68k-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-mips.rb
+++ b/macos/binutils-mips.rb
@@ -10,6 +10,7 @@ class BinutilsMips < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=mips-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-mips64.rb
+++ b/macos/binutils-mips64.rb
@@ -10,6 +10,7 @@ class BinutilsMips64 < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=mips64-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-msp430.rb
+++ b/macos/binutils-msp430.rb
@@ -10,6 +10,7 @@ class BinutilsMsp430 < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=msp430-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-powerpc.rb
+++ b/macos/binutils-powerpc.rb
@@ -10,6 +10,7 @@ class BinutilsPowerpc < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=powerpc-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-powerpc64.rb
+++ b/macos/binutils-powerpc64.rb
@@ -10,6 +10,7 @@ class BinutilsPowerpc64 < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=powerpc64-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-s390.rb
+++ b/macos/binutils-s390.rb
@@ -10,6 +10,7 @@ class BinutilsS390 < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=s390-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-sparc.rb
+++ b/macos/binutils-sparc.rb
@@ -10,6 +10,7 @@ class BinutilsSparc < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=sparc-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-sparc64.rb
+++ b/macos/binutils-sparc64.rb
@@ -10,6 +10,7 @@ class BinutilsSparc64 < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=sparc64-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-vax.rb
+++ b/macos/binutils-vax.rb
@@ -10,6 +10,7 @@ class BinutilsVax < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=vax-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-x86_64.rb
+++ b/macos/binutils-x86_64.rb
@@ -10,6 +10,7 @@ class BinutilsX8664 < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=x86_64-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/binutils-xscale.rb
+++ b/macos/binutils-xscale.rb
@@ -10,6 +10,7 @@ class BinutilsXscale < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=xscale-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",

--- a/macos/generate.sh
+++ b/macos/generate.sh
@@ -23,6 +23,7 @@ class Binutils$(title_case $arch) < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--libdir=#{prefix}/#{name}",
                           "--target=$arch-unknown-linux-gnu",
                           "--disable-static",
                           "--disable-multilib",


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/pull/79874

```shell
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /opt/homebrew
Could not symlink lib/bfd-plugins/libdep.so
Target /opt/homebrew/lib/bfd-plugins/libdep.so
is a symlink belonging to binutils-aarch64. You can unlink it:
  brew unlink binutils-aarch64

To force the link and overwrite all conflicting files:
  brew link --overwrite binutils-amd64

To list all files that would be deleted:
  brew link --overwrite --dry-run binutils-amd64

Possible conflicting files are:
/opt/homebrew/lib/bfd-plugins/libdep.so -> /opt/homebrew/Cellar/binutils-aarch64/2.38/lib/bfd-plugins/libdep.so
```